### PR TITLE
Replace 'lc' comprehensions with 'for'

### DIFF
--- a/lib/mime/types.ex
+++ b/lib/mime/types.ex
@@ -48,8 +48,8 @@ defmodule MIME.Types do
 
   @spec type(String.t) :: String.t
 
-  lc { type, exts } inlist mapping do
-    lc ext inlist exts do
+  for { type, exts } <- mapping do
+    for ext <- exts do
       def type(unquote(ext)), do: unquote(type)
     end
   end
@@ -73,7 +73,7 @@ defmodule MIME.Types do
 
   # entry/1
 
-  lc { type, exts } inlist mapping do
+  for { type, exts } <- mapping do
     defp entry(unquote(type)), do: unquote(exts)
   end
 


### PR DESCRIPTION
'lc' comprehensions are getting deprecated in 0.13.2, we might as well get rid of them as soon as possible.
